### PR TITLE
Do not remove empty lines in fragments 

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const fs = require('fs')
 const path = require('path')
 const child_process = require('child_process')
+const unindent = require('unindent')
 
 module.exports = {
   hooks: {
@@ -83,10 +84,4 @@ module.exports = {
         })
     }
   }
-}
-
-const unindent = s => {
-  // https://twitter.com/gasparnagy/status/778134306128551940
-  for (; !s.match(/^\S/m); s = s.replace(/^\s/gm, ''));
-  return s
 }

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "homepage": "https://github.com/cucumber-ltd/gitbook-plugin-snippet#readme",
   "devDependencies": {
     "mocha": "^3.0.2"
+  },
+  "dependencies": {
+    "unindent": "^2.0.0"
   }
 }

--- a/test/fragment.js
+++ b/test/fragment.js
@@ -1,7 +1,9 @@
 function fragment() {
   /// [the-fragment]
   if (true) {
-    console.log("the fragment")
+    console.log("the fragment 1")
+
+    console.log("the fragment 2")
   }
   /// [the-fragment]
 }

--- a/test/fragment.rb
+++ b/test/fragment.rb
@@ -1,7 +1,9 @@
 class Fragment
   ### [the-fragment]
   if true
-    puts "the fragment"
+    puts "the fragment 1"
+
+    puts "the fragment 2"
   end
   ### [the-fragment]
 end

--- a/test/snippet_test.js
+++ b/test/snippet_test.js
@@ -58,8 +58,11 @@ two
     return plugin.hooks['page:before'].bind(instance)(page)
       .then(() => {
         const expected = `one
+
 if true
-  puts "the fragment"
+  puts "the fragment 1"
+
+  puts "the fragment 2"
 end
 
 two
@@ -79,8 +82,11 @@ two
     return plugin.hooks['page:before'].bind(instance)(page)
       .then(() => {
         const expected = `one
+
 if (true) {
-  console.log("the fragment")
+  console.log("the fragment 1")
+
+  console.log("the fragment 2")
 }
 
 two
@@ -136,6 +142,7 @@ two
       return plugin.hooks['page:before'].bind(instance)(page)
         .then(() => {
           const expected = `one
+
 if true
   puts "the fragment"
 end

--- a/test/snippet_test.js
+++ b/test/snippet_test.js
@@ -103,7 +103,7 @@ two
         .then(() => {
           const expected = `[snippet](nosuch.js) *FILE NOT FOUND: nosuch.js*`
           assert.equal(page.content, expected)
-          assert.deepEqual(warnings, ["nosuch.js: " + expected])
+          assert.deepEqual(warnings.map(x => x.trim()), ["nosuch.js: " + expected])
           assert.deepEqual(errors, [])
         })
     })
@@ -117,7 +117,7 @@ two
         .then(() => {
           const expected = `[snippet](hello.rb#nosuch) *FRAGMENT NOT FOUND: hello.rb#nosuch*`
           assert.equal(page.content, expected)
-          assert.deepEqual(warnings, ["hello.rb: " + expected])
+          assert.deepEqual(warnings.map(x => x.trim()), ["hello.rb: " + expected])
           assert.deepEqual(errors, [])
         })
     })
@@ -125,19 +125,20 @@ two
 
   describe("git history", () => {
     it("includes the fragment from file based on commit message", () => {
-      const commitMessage = "very special"
+      const commitMessage = "First commit"
       const page = {
         rawPath: __filename,
         content: `one
-[snippet](on-branch.rb#marker@${commitMessage})
+[snippet](fragment.rb#the-fragment@${commitMessage})
 two
 `
       }
       return plugin.hooks['page:before'].bind(instance)(page)
         .then(() => {
           const expected = `one
-
-puts "world"
+if true
+  puts "the fragment"
+end
 
 two
 `


### PR DESCRIPTION
1. Fix tests in master.
2. Replace a custom `unindent` function that strips empty lines with the unindent package.